### PR TITLE
Add support for #skittle_color

### DIFF
--- a/lib/skittlize.rb
+++ b/lib/skittlize.rb
@@ -20,12 +20,15 @@ class Array
 end
 
 class String
-  def skittlize
+  def skittle_color
     n = Integer(Digest::MD5.hexdigest("#{self}\n")[-2..-1], 16)
     n %= 231
     n += 17 if [0, 15, 16].include?(n)
+    n
+  end
 
-    "\033[38;5;#{n}m#{self}\033[0m"
+  def skittlize
+    "\033[38;5;#{skittle_color}m#{self}\033[0m"
   end
 
   def skittlize!

--- a/spec/skittlize_spec.rb
+++ b/spec/skittlize_spec.rb
@@ -2,6 +2,11 @@ RSpec.describe Skittlize do
   describe 'String' do
     let(:original) { 'Hello World' }
 
+    describe '#skittle_color' do
+      let(:subject) { original.skittle_color }
+      it { is_expected.to eq(96) }
+    end
+
     describe '#skittlize' do
       let(:subject) { original.skittlize }
       it { is_expected.to eq("\033[38;5;96mHello World\033[0m") }


### PR DESCRIPTION
Return the color value for a given string instead of coloring the
string.  Useful when generating configuration files.