### PR TITLE
Allow to skittlize parts of strings

### DIFF
--- a/lib/skittlize.rb
+++ b/lib/skittlize.rb
@@ -1,21 +1,19 @@
 require 'digest'
 
 class Array
-  def skittlize
+  def skittlize(options = {})
     map do |cell|
       case cell
-      when Array
-        cell.skittlize
-      when String
-        cell.skittlize
+      when Array, String
+        cell.skittlize(options)
       else
         cell
       end
     end
   end
 
-  def skittlize!
-    replace(skittlize)
+  def skittlize!(options = {})
+    replace(skittlize(options))
   end
 end
 
@@ -27,11 +25,25 @@ class String
     n
   end
 
-  def skittlize
-    "\033[38;5;#{skittle_color}m#{self}\033[0m"
+  def skittlize(options = {})
+    check_options(options)
+
+    if options[:split]
+      split(options[:split]).map(&:skittlize).join(options[:join] || options[:split])
+    else
+      "\033[38;5;#{skittle_color}m#{self}\033[0m"
+    end
   end
 
-  def skittlize!
-    replace(skittlize)
+  def skittlize!(options = {})
+    replace(skittlize(options))
+  end
+
+  private
+
+  def check_options(options)
+    extra_options = options.keys - [:split, :join]
+
+    raise "Unsupported options: #{extra_options}" if extra_options.any?
   end
 end

--- a/spec/string_spec.rb
+++ b/spec/string_spec.rb
@@ -17,12 +17,30 @@ RSpec.describe String do
   end
 
   describe '#skittlize' do
-    let(:subject) { string.skittlize }
+    let(:subject) { string.skittlize(options) }
 
-    it { is_expected.to eq("\033[38;5;96mHello World\033[0m") }
-    it 'should not replace the original Object' do
-      subject
-      expect(string).to eq('Hello World')
+    context 'without options' do
+      let(:options) { {} }
+
+      it { is_expected.to eq("\033[38;5;96mHello World\033[0m") }
+      it 'should not replace the original Object' do
+        subject
+        expect(string).to eq('Hello World')
+      end
+    end
+
+    context 'with :split option' do
+      let(:string) { "#{a}\n#{b}\n#{c}" }
+      let(:options) { { split: "\n" } }
+
+      it { is_expected.to eq("#{colored_a}\n#{colored_b}\n#{colored_c}") }
+    end
+
+    context 'with :split and :join option' do
+      let(:string) { "#{a}\0#{b}\0#{c}" }
+      let(:options) { { split: "\0", join: "\n" } }
+
+      it { is_expected.to eq("#{colored_a}\n#{colored_b}\n#{colored_c}") }
     end
   end
 


### PR DESCRIPTION
When skittling a string, allow it to be split before colorization and
join the pieces after that.

```ruby
<<EOT.skittlize(split: "\n", join: ', ')
ecdsa
ec25519
rsa
EOT
```